### PR TITLE
uses global position config when not overwritten

### DIFF
--- a/lib/SAlert.js
+++ b/lib/SAlert.js
@@ -8,7 +8,7 @@ const insertFunc = (msg, data, condition) => {
     let id = sAlertTools.randomId();
     sAlertStore.dispatch({
         type: 'INSERT',
-        data: Object.assign({position: 'top-right'}, data, {
+        data: Object.assign({}, data, {
             id: id,
             condition: condition,
             message: msg
@@ -112,7 +112,7 @@ class SAlert extends React.Component {
             stack: this.props.stack,
             html: this.props.html,
             customFields: this.props.customFields,
-            position: this.props.position
+            position: this.props.position || 'top-right'
         };
         sAlertTools.setGlobalConfig(globalConfig);
     }

--- a/lib/__tests__/index.js
+++ b/lib/__tests__/index.js
@@ -150,6 +150,22 @@ describe('sAlert position bottom-left', () => {
     after(() => Alert.closeAll());
 });
 
+describe('sAlert global position config', () => {
+    let renderedComp;
+    let sAlertId;
+
+    before(() => {
+        renderedComp = mount(<Alert position='bottom-right' timeout='none' />);
+        sAlertId = Alert.success('Test global position...');
+    });
+
+    it('should have s-alert-bottom-right class', () => {
+        expect(renderedComp.find('.s-alert-bottom-right')).to.have.length(1);
+    });
+
+    after(() => Alert.closeAll());
+});
+
 describe('sAlert position full width top', () => {
     let renderedComp;
     let sAlertId;


### PR DESCRIPTION
This fixes an issue where specifying a global position config, any subsequent calls to Alert, resets the position back to the default "top-right".