### PR TITLE
Fix syntax error in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ In global config:
 <Alert beep={{
     info: '/path-to-audio/file-info.mp3',
     error: '/path-to-audio/file-error.mp3',
-    warning: '/path-to-audio/file-warning.mp3'
+    warning: '/path-to-audio/file-warning.mp3',
     success: '/path-to-audio/file-success.mp3'}} />
 ```
 or just one for all:


### PR DESCRIPTION
Pretty minor stuff ;)

One of the lines in a code example is missing a "," at the end