### PR TITLE
add `style` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "bugs": {
     "url": "https://github.com/juliancwirko/react-s-alert/issues"
   },
+  "style": "dist/s-alert-default.css",
   "homepage": "https://github.com/juliancwirko/react-s-alert",
   "keywords": [
     "react-component",


### PR DESCRIPTION
Adding a `style` field to your npm package makes it compatible with [sass-module-importer](https://github.com/lucasmotta/sass-module-importer), which is a nice way to import css into your sass project directly from `node_modules` without relying on the ugly `../../` imports.

I would also recommend compiling a `react-s-full.css` file (that includes everything needed to use react-s-alert, including animations), and then set that as the `style` for your module.

The CSS files are not so big to warrant them being in their separate files, or at least for me, it was counter-intuitive. Either way, I don't think adding a full build could hurt :)