### PR TITLE
Add missing enzyme dependencies to run tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,9 +53,10 @@
     "jsdom": "^9.12.0",
     "mocha": "^3.2.0",
     "nodemon": "^1.11.0",
+    "prop-types": "^15.5.4",
     "react": "^15.5.0",
     "react-dom": "^15.5.0",
-    "prop-types": "^15.5.4"
+    "react-test-renderer": "^15.5.4"
   },
   "peerDependencies": {
     "react": "^15.0.0",


### PR DESCRIPTION
This fixes the errors when running `npm test`:
```
react-dom@15.5+ and react-test-renderer are implicit dependencies when usingreact@15.5+ with enzyme. Please add the appropriate version to yourdevDependencies. See https://github.com/airbnb/enzyme#installation
./react-s-alert/node_modules/enzyme/build/react-compat.js:154
      throw e;
      ^

Error: Cannot find module 'react-addons-test-utils'
    at Function.Module._resolveFilename (module.js:470:15)
    at Function.Module._load (module.js:418:25)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    ...
```

From enzyme docs:
If you are using React >=15.5, in addition to enzyme, you will have to ensure that you also have the following npm modules installed if they were not already:

npm i --save-dev react-test-renderer react-dom
