### PR TITLE
Immediately run listeners when initially subscribing

### DIFF
--- a/dist/SAlert.js
+++ b/dist/SAlert.js
@@ -118,6 +118,19 @@
             value: function componentDidMount() {
                 var _this2 = this;
 
+                // set up global config from global SAlert props
+                // only stuff needed for getAlertData
+                var globalConfig = {
+                    contentTemplate: this.props.contentTemplate,
+                    offset: this.props.offset,
+                    message: this.props.message,
+                    stack: this.props.stack,
+                    html: this.props.html,
+                    customFields: this.props.customFields,
+                    position: this.props.position || 'top-right'
+                };
+                _sAlertTools2.default.setGlobalConfig(globalConfig);
+
                 var storeStateLeft = void 0;
                 var storeStateRight = void 0;
                 var storeStateTop = void 0;
@@ -174,19 +187,6 @@
                     _this2.setState({ dataBottom: storeStateBottom });
                 };
                 this.unsubStoreBottom = _sAlertStore2.default.subscribe(addToStoreBottom);
-
-                // set up global config from global SAlert props
-                // only stuff needed for getAlertData
-                var globalConfig = {
-                    contentTemplate: this.props.contentTemplate,
-                    offset: this.props.offset,
-                    message: this.props.message,
-                    stack: this.props.stack,
-                    html: this.props.html,
-                    customFields: this.props.customFields,
-                    position: this.props.position || 'top-right'
-                };
-                _sAlertTools2.default.setGlobalConfig(globalConfig);
             }
         }, {
             key: 'componentWillUnmount',

--- a/dist/s-alert-parts/s-alert-store.js
+++ b/dist/s-alert-parts/s-alert-store.js
@@ -45,6 +45,7 @@
         };
         var subscribe = function subscribe(listener) {
             listeners.push(listener);
+            listener();
             return function () {
                 listeners = listeners.filter(function (l) {
                     return l !== listener;

--- a/lib/SAlert.js
+++ b/lib/SAlert.js
@@ -47,6 +47,19 @@ class SAlert extends React.Component {
         sAlertStore.dispatch({type: 'REMOVEALL'});
     }
     componentDidMount() {
+        // set up global config from global SAlert props
+        // only stuff needed for getAlertData
+        const globalConfig = {
+            contentTemplate: this.props.contentTemplate,
+            offset: this.props.offset,
+            message: this.props.message,
+            stack: this.props.stack,
+            html: this.props.html,
+            customFields: this.props.customFields,
+            position: this.props.position || 'top-right'
+        };
+        sAlertTools.setGlobalConfig(globalConfig);
+
         let storeStateLeft;
         let storeStateRight;
         let storeStateTop;
@@ -103,19 +116,6 @@ class SAlert extends React.Component {
             this.setState({dataBottom: storeStateBottom});
         };
         this.unsubStoreBottom = sAlertStore.subscribe(addToStoreBottom);
-
-        // set up global config from global SAlert props
-        // only stuff needed for getAlertData
-        const globalConfig = {
-            contentTemplate: this.props.contentTemplate,
-            offset: this.props.offset,
-            message: this.props.message,
-            stack: this.props.stack,
-            html: this.props.html,
-            customFields: this.props.customFields,
-            position: this.props.position || 'top-right'
-        };
-        sAlertTools.setGlobalConfig(globalConfig);
     }
     componentWillUnmount() {
         this.unsubStoreTop();

--- a/lib/__tests__/index.js
+++ b/lib/__tests__/index.js
@@ -130,6 +130,30 @@ describe('sAlert 1000ms timeout', () => {
     after(() => Alert.closeAll());
 });
 
+describe('sAlert mount after issuing alert', () => {
+    let renderedComp;
+    let sAlertId;
+
+    before((done) => {
+        sAlertId = Alert.success('Test delayed mount...', {timeout: 'none', position: 'top-right'});
+
+        setTimeout(() => {
+            renderedComp = mount(<Alert />);
+            done();
+        }, 1000);
+    });
+
+    it('should be s-alert in the s-alert store', () => {
+        expect(sAlertStore.getState()[0].message).to.equal('Test delayed mount...');
+        expect(sAlertStore.getState()[0].condition).to.equal('success');
+    });
+    it('should be ".s-alert-success" element in the DOM', () => {
+        expect(renderedComp.find('.s-alert-success').length).to.be.equal(1);
+    });
+
+    after(() => Alert.closeAll());
+});
+
 describe('sAlert position bottom-left', () => {
     let renderedComp;
     let sAlertId;

--- a/lib/s-alert-parts/s-alert-store.js
+++ b/lib/s-alert-parts/s-alert-store.js
@@ -10,6 +10,7 @@ const createSAlertStore = (reducer) => {
     };
     const subscribe = (listener) => {
         listeners.push(listener);
+        listener();
         return () => {
             listeners = listeners.filter(l => l !== listener);
         };


### PR DESCRIPTION
I issue Alerts prior to mounting the SAlert component.  The Alerts would pile up in state until another Alert was issued after the component mounted, at which point all the alerts would be processed.