### PR TITLE
Allow passing of alert id into configObj

### DIFF
--- a/dist/SAlert.js
+++ b/dist/SAlert.js
@@ -98,7 +98,7 @@
     };
 
     var insertFunc = function insertFunc(msg, data, condition) {
-        var id = _sAlertTools2.default.randomId();
+        var id = data.id || _sAlertTools2.default.randomId();
         _sAlertStore2.default.dispatch({
             type: 'INSERT',
             data: _extends({}, data, {

--- a/dist/SAlertContent.js
+++ b/dist/SAlertContent.js
@@ -189,8 +189,9 @@
                 var handleClose = this.handleCloseAlert.bind(this);
                 var contentTemplate = this.props.contentTemplate || _SAlertContentTmpl2.default;
                 var customFields = this.props.customFields || {};
+                var condition = this.props.condition;
 
-                return _react2.default.createElement(contentTemplate, { classNames: classNames, id: id, styles: styles, message: message, handleClose: handleClose, customFields: customFields });
+                return _react2.default.createElement(contentTemplate, { classNames: classNames, id: id, styles: styles, message: message, handleClose: handleClose, customFields: customFields, condition: condition });
             }
         }]);
 

--- a/dist/SAlertContentTmpl.js
+++ b/dist/SAlertContentTmpl.js
@@ -106,6 +106,7 @@
     SAlertContentTmpl.propTypes = {
         id: _propTypes2.default.string.isRequired,
         classNames: _propTypes2.default.string.isRequired,
+        condition: _propTypes2.default.string.isRequired,
         styles: _propTypes2.default.object.isRequired,
         message: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.object]).isRequired,
         handleClose: _propTypes2.default.func.isRequired,

--- a/lib/SAlert.js
+++ b/lib/SAlert.js
@@ -6,7 +6,7 @@ import sAlertTools from './s-alert-parts/s-alert-tools';
 import getAlertData from './s-alert-parts/s-alert-data-prep';
 
 const insertFunc = (msg, data, condition) => {
-    let id = sAlertTools.randomId();
+    const id = data.id || sAlertTools.randomId();
     sAlertStore.dispatch({
         type: 'INSERT',
         data: Object.assign({}, data, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,7 @@
 {
   "name": "react-s-alert",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
     "@types/node": {
       "version": "6.0.90",
@@ -4387,6 +4386,15 @@
         "duplexer": "0.1.1"
       }
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -4396,15 +4404,6 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {


### PR DESCRIPTION
Currently you cannot use your own `alertId`s when creating a notification. This is problematic if you have a react component as the message to be displayed and you want it to be dismissible by a close handle. There is no way to know the `alertId` at the component level because it is not passed in and the only way to dismiss the notification would be via the `closeAll()` method which is not ideal if there's more than one notification displayed.

This PR allows id to be passed in via the `configObj` and falls back to normal behaviour if it's not present.

My solution will be to pass in an id generated by `sAlertTools.randomId()` and should be the recommended way. I have imported it into my code via. You may wish to provide a better interface.

`import sAlertTools from 'react-s-alert/dist/s-alert-parts/s-alert-tools';`
